### PR TITLE
Fix Mac compatibility issues: np.int deprecation, camera handling, an…

### DIFF
--- a/promap/__init__.py
+++ b/promap/__init__.py
@@ -378,8 +378,8 @@ def op_invert(args):
             im = int_to_float(im)
             x = im[:,:,2]
             y = im[:,:,1]
-            x = np.round(x * args.projector_size[0]).astype(np.int)
-            y = np.round(y * args.projector_size[1]).astype(np.int)
+            x = np.round(x * args.projector_size[0]).astype(int)
+            y = np.round(y * args.projector_size[1]).astype(int)
         else:
             x = im[:,:,2]
             y = im[:,:,1]
@@ -464,8 +464,8 @@ def op_reproject(args):
             im = int_to_float(im)
             x = im[:,:,2]
             y = im[:,:,1]
-            x = np.round(x * args.camera_size[0]).astype(np.int)
-            y = np.round(y * args.camera_size[1]).astype(np.int)
+            x = np.round(x * args.camera_size[0]).astype(int)
+            y = np.round(y * args.camera_size[1]).astype(int)
             args.lookup_image = np.dstack((x, y))
         else:
             args.lookup_image = np.dstack((im[:,:,2], im[:,:,1]))

--- a/promap/capture.py
+++ b/promap/capture.py
@@ -1,6 +1,7 @@
 import promap
 import cv2
 import logging
+import platform
 import threading
 import time
 
@@ -9,11 +10,15 @@ class CaptureError(promap.PromapError):
 
 def open_camera(camera):
     if camera is None:
-        cap = cv2.VideoCapture()
+        cap = cv2.VideoCapture(0)
         if not cap.isOpened():
-            raise CaptureError("Could not open default capture device") 
+            raise CaptureError("Could not open default capture device")
     else:
-        cap = cv2.VideoCapture(camera)
+        try:
+            camera_id = int(camera)
+        except (ValueError, TypeError):
+            camera_id = camera
+        cap = cv2.VideoCapture(camera_id)
         if not cap.isOpened():
             raise CaptureError("Could not open {}".format(camera))
     return cap
@@ -63,7 +68,8 @@ def perform_capture(cap):
 def capture(camera, width, height):
     # Open camera
     cap = open_camera(camera)
-    cap.set(cv2.CAP_PROP_SETTINGS, 1)
+    if platform.system() != "Darwin":
+        cap.set(cv2.CAP_PROP_SETTINGS, 1)
     cap.set(cv2.CAP_PROP_FRAME_WIDTH, width)
     cap.set(cv2.CAP_PROP_FRAME_HEIGHT, height)
     w = cap.get(cv2.CAP_PROP_FRAME_WIDTH)

--- a/setup.py
+++ b/setup.py
@@ -30,6 +30,8 @@ setuptools.setup(
     install_requires=[
         'numpy',
         'scipy',
+        'opencv-python',
+        'PyQt5',
     ],
     entry_points = {
         'console_scripts': ['promap=promap:main'],


### PR DESCRIPTION
…d deps

- Replace deprecated np.int with built-in int (crashes on NumPy 1.24+)
- Fix camera device opening to accept integer IDs (required on macOS AVFoundation)
- Use VideoCapture(0) instead of VideoCapture() for default device
- Skip CAP_PROP_SETTINGS on macOS where it's unsupported
- Add missing opencv-python and PyQt5 to install_requires

https://claude.ai/code/session_016cqKigjVx4QuEWZWNpkJ7d